### PR TITLE
Install redis python module with apk

### DIFF
--- a/stun/Dockerfile
+++ b/stun/Dockerfile
@@ -4,12 +4,10 @@ FROM alpine:latest
 ENV rootpath /app
 
 RUN apk update && \
-    apk add python3
+    apk add python3 py3-redis
 
 ADD target/ $rootpath/
 
 WORKDIR $rootpath
-
-RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
Initially the error message occurs that `pip3` cannot be found. 
```log
 => ERROR [stun 5/5] RUN pip3 install -r requirements.txt                                                                                                                                                     0.3s
------                                                                                                                                                                                                             
 > [stun 5/5] RUN pip3 install -r requirements.txt:
0.267 /bin/sh: pip3: not found
```

Solution #1 unfortunately did not work for me, because latest Alpine was complaining about breaking system dependencies. Probably a virtual environment would be the best solution. 

Therefore this is an alternative approach with installing the `redis` module with the `apk` package manager directly.