### PR TITLE
Debian upgrade using stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This is a image of cossacks game server
-FROM debian:stretch-slim
+FROM debian:stable-slim
 EXPOSE 34001
 
 ARG rootpath=/app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # This is a image of cossacks game server
-FROM debian:stretch-slim
+FROM debian:stable-slim
 EXPOSE 34001
 
 ENV rootpath /app

--- a/stun/Dockerfile
+++ b/stun/Dockerfile
@@ -4,12 +4,10 @@ FROM alpine:latest
 ENV rootpath /app
 
 RUN apk update && \
-    apk add python3
+    apk add python3 py3-redis
 
 ADD target/ $rootpath/
 
 WORKDIR $rootpath
-
-RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/stun/Dockerfile
+++ b/stun/Dockerfile
@@ -4,10 +4,12 @@ FROM alpine:latest
 ENV rootpath /app
 
 RUN apk update && \
-    apk add python3 py3-redis
+    apk add python3
 
 ADD target/ $rootpath/
 
 WORKDIR $rootpath
+
+RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
Upgrade Debian, because `stretch` is already archived and `build-essential` cannot be retrieved from the `sources.list` anymore:
```bash
failed to solve: process "/bin/sh -c apt-get update -q --fix-missing &&     apt-get -y upgrade &&     apt-get -y install build-essential" did not complete successfully: exit code: 100
```

Therefore proposing to use Debian stable from now on. 