### PR TITLE
Retrieve uid, guid from .env, fixes root owner for volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   irc:
     image: geekduck/ngircd
@@ -16,6 +15,7 @@ services:
     ports:
       - "3708:3708/udp"
   cossacks:
+    user: "${UID}:${GID}"
     build:
       context: ./
       dockerfile: Dockerfile.dev

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ For *nix systems run start.sh and make sure that variable *HOST_NAME* in ".env" 
 INSTALLATION:
 1. git clone https://github.com/envy124/CossacksGameServer; cd CossacksGameServer
 2. echo "HOST_NAME=YOUR_HOSTNAME" > .env
-
+3. `echo "UID=$(id -u)" >> .env; echo "GID=$(id -g)" >> .env`
 
 Use "./start.sh" to run server
 


### PR DESCRIPTION
Get current user's `uid` and `guid` and write into `.env` file. 
`volumes` directory will now have the permission of that current user. 